### PR TITLE
Resolve Leaflet's `Mixins` Deprecation notice backwards compatibly

### DIFF
--- a/src/leaflet.buffer.js
+++ b/src/leaflet.buffer.js
@@ -113,7 +113,7 @@ L.EditToolbar.Buffer = L.Handler.extend({
     TYPE: 'buffer',
   },
 
-  includes:        L.Mixin.Events,
+  includes:        L.Evented ? L.Evented.prototype : L.Mixin.Events,
   _draggingLayer:  null,
   _originalLayers: {},
   _bufferData:     {},


### PR DESCRIPTION
Leaflet throws a Mixin deprecation notice to console because of the use of Mixins. Including the Evented prototype instead and falling back to Mixin for older versions of Leaflet where Mixins is the only option, maintains backwards compatibility of Leaflet.Buffer with pre leaflet 1.10 versions.
<img width="755" height="99" alt="leaflet-mixins deprecation" src="https://github.com/user-attachments/assets/6234fda1-7095-45ba-8105-3bea509e977c" />
